### PR TITLE
Fix parameter name mismatch in ProjectPage component

### DIFF
--- a/nextjs/app/(dashboard)/project/[projectid]/page.tsx
+++ b/nextjs/app/(dashboard)/project/[projectid]/page.tsx
@@ -6,19 +6,19 @@ import React from "react";
 
 interface ProjectPageProps {
   params: {
-    projectId: string;
+    projectid: string;
   };
 }
 
 export default async function ProjectPage({ params }: ProjectPageProps) {
   console.log(`ProjectPage: Received params`, params);
 
-  if (!params || !params.projectId) {
+  if (!params || !params.projectid) {
     console.error(`ProjectPage: Project ID is undefined or missing`);
     return notFound();
   }
 
-  const projectId = params.projectId;
+  const projectId = params.projectid;
   console.log(`ProjectPage: Attempting to fetch project ${projectId}`);
 
   try {

--- a/nextjs/server/queries.ts
+++ b/nextjs/server/queries.ts
@@ -65,6 +65,10 @@ export async function getProject(projectId: string) {
       );
     } else {
       console.log(`getProject: Project ${projectId} found for user ${userId}`);
+      console.log(
+        `getProject: Verifying project details:`,
+        JSON.stringify(project, null, 2)
+      );
     }
 
     return project;


### PR DESCRIPTION
Updated the ProjectPage component to correctly reference the project ID parameter as 'projectid' instead of 'projectId'. This resolves the issue where the project ID was reported as undefined, leading to 404 errors when accessing project pages.